### PR TITLE
Numera punkter som vi gör i föredragningslistor

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,7 +6,7 @@ class Item < ApplicationRecord
   self.inheritance_column = :_type_disabled
 
   acts_as_paranoid
-  acts_as_list(scope: [deleted_at: nil])
+  #acts_as_list(scope: [deleted_at: nil])
 
   has_many(:sub_items, -> { position }, dependent: :destroy,
                                         inverse_of: :item)
@@ -50,6 +50,21 @@ class Item < ApplicationRecord
   def to_param
     "#{id}-#{title.try(:parameterize)}"
   end
+  
+  def next
+    Item.position.each_cons(2) do |item, item_next|
+      return item_next if position === item.position
+    end
+    return nil
+  end
+
+  def prev
+    Item.position.each_cons(2) do |item, item_next|
+      return item if position === item_next.position
+    end
+    return nil
+  end
+
 
   private
 

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for([:admin, item]) do |f| %>
   <%= f.input(:title, autofocus: true) %>
   <%= f.input(:type, collection: item_types, include_blank: false) %>
-  <%= f.input(:position, as: :integer, input_html: { min: '1'}) %>
+  <%= f.input(:position) %>
   <%= f.button(:submit) %>
 <% end %>

--- a/config/initializers/numeric.rb
+++ b/config/initializers/numeric.rb
@@ -1,0 +1,40 @@
+# https://codereview.stackexchange.com/a/7939
+# https://stackoverflow.com/a/14632986
+
+class Numeric
+  ROMAN_NUMBERS = {
+    1000 => "m",  
+     900 => "cm",  
+     500 => "d",  
+     400 => "cd",
+     100 => "c",  
+      90 => "xc",  
+      50 => "l",  
+      40 => "xl",  
+      10 => "x",  
+       9 => "ix",  
+       5 => "v",  
+       4 => "iv",  
+       1 => "i",  
+  }
+  ALPH_SET = ("a".."z").to_a
+
+  def roman
+    n = self
+    roman = ""
+    ROMAN_NUMBERS.each do |value, letter|
+      roman << letter*(n / value)
+      n = n % value
+    end
+    return roman
+  end
+
+  def alph
+    s, q = "", self
+    until q < 1
+      q, r = (q - 1).divmod(26)
+      s.prepend(ALPH_SET[r])
+    end
+    return s
+  end
+end

--- a/db/migrate/20201001095739_item_position_to_string.rb
+++ b/db/migrate/20201001095739_item_position_to_string.rb
@@ -1,0 +1,8 @@
+class ItemPositionToString < ActiveRecord::Migration[5.2]
+  def up
+    change_column :items, :position, :string
+  end
+  def down
+    change_column :items, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_02_09_100515) do
-
+ActiveRecord::Schema.define(version: 2020_10_01_095739) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
@@ -85,7 +84,7 @@ ActiveRecord::Schema.define(version: 2018_02_09_100515) do
     t.string "title", null: false
     t.integer "type", default: 0, null: false
     t.integer "multiplicity", default: 0, null: false
-    t.integer "position"
+    t.string "position"
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :item do
     title
-    position { |n| n }
+    position
   end
 end

--- a/spec/requests/admin/handle_items_spec.rb
+++ b/spec/requests/admin/handle_items_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe('Handle items', as: :request) do
 
   describe 'create' do
     it 'correct attributes' do
-      attributes = { title: 'Motioner', position: 10, type: :election }
+      attributes = { title: 'Motioner', position: '10', type: :election }
       sign_in(adjuster)
 
       get(new_admin_item_url)


### PR DESCRIPTION
Med denna patch kan huvudpunkter ges godtycklig sträng som etikett och sedan sorteras lexikografiskt.
Detta för att möjliggöra att underpunkter för huvudpunkter som snarare är grupperingar kan tas upp tydligt i systemet.
Om en huvuvdpunkt är numerisk kommer underpunkter tas upp med bokstäver. I annat fall tas de upp med romerska siffror. 

Resultatet blir att numeringen förhoppningsvis kommer närmare vad vi skriver i praktiken i kallelse, föredragningslista och protokoll; vi räknar upp punkter först med arabiska siffror, sedan med alfabetet, och sist med romerska siffor.

OBS: förändrar schema för databasen. Glöm ej `bin/rake db:migrate`