### PR TITLE
Knappar i stället för fält när man röstar på två alternativ

### DIFF
--- a/app/assets/stylesheets/style/custom.scss
+++ b/app/assets/stylesheets/style/custom.scss
@@ -42,3 +42,40 @@ li {
 .text-gray {
   color: theme-color('gray');
 }
+
+.radio_buttons {
+  & .form-check {
+    display: flex;
+    & .radio {
+      display: block;
+      flex: 1 1;
+      text-align: center;
+      & input {
+        display: none;
+      }
+      & label {
+        display: block;
+        margin: 0 1rem;
+        padding: 0.375rem 0.75rem;
+        background-color: theme-color('gray');
+        user-select: none;
+        font-size: 1rem;
+        line-height: 1.5;
+        border-radius: 0.25rem;
+        transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+        border: 1px solid transparent;
+        &:hover {
+          border: 1px solid theme-color('black');
+        }
+      }
+      & input:checked ~ label {
+        color: theme-color('primary');
+        border: 1px solid theme-color('primary');
+        &::before {
+          content: "\2713  ";
+          font-weight: bold;
+        }
+      }
+    }
+  }
+}

--- a/app/views/vote_posts/_form.html.erb
+++ b/app/views/vote_posts/_form.html.erb
@@ -1,16 +1,20 @@
 <%= simple_form_for([vote, vote_post], remote: true) do |f| %>
-  <p><i><%= t('.max_choices', choices: vote.choices) %></i></p>
-  <% if vote_post.errors[:user_id].present? %>
-    <% vote_post.errors[:user_id].each do |error| %>
-      <span class="error">
-        <%= fa_icon('exclamation-circle') %>
-        <%= error.to_s %>
-      </span>
+  <% if vote.choices == 1 and vote.vote_options.size == 2 %>
+    <%= f.input :vote_option_ids, collection: vote.vote_options, as: :radio_buttons, label: false,
+      include_blank: false, include_hidden: false, input_html: { name: 'vote_post[vote_option_ids][]' }%>
+  <% else %>
+    <p><i><%= t('.max_choices', choices: vote.choices) %></i></p>
+    <% if vote_post.errors[:user_id].present? %>
+      <% vote_post.errors[:user_id].each do |error| %>
+        <span class="error">
+          <%= fa_icon('exclamation-circle') %>
+          <%= error.to_s %>
+        </span>
+      <% end %>
     <% end %>
+    <%= f.input :vote_option_ids, collection: vote.vote_options.order(:title), include_blank: false,
+      input_html: { class: 'select2-single', multiple: true }, include_hidden: false %>
   <% end %>
-
-  <%= f.input :vote_option_ids, collection: vote.vote_options.order(:title), include_blank: false,
-    input_html: { class: 'select2-single', multiple: true }, include_hidden: false %>
   <%= f.button :submit, t('.submit'), id: 'vote_post_submit',
-                                      data: { confirm: t('.confirm') } %>
+    data: { confirm: t('.confirm') } %>
 <% end %>


### PR DESCRIPTION
Om en omröstning bara har 2 alternativ varav 1 får väljas, visas i stället två knappar med alternativen som etikett. Än så länge åsidosätts inte UX för att skicka rösten (dvs. välj -> tryck "Rösta" -> bekräfta i dialogen) men det kan vara av intresse efter att vi testat detta lite.

Det här funktionaliteten kan behövas om vi beslutar oss för att flytta alla former av votering till systemet. Men denna pr går händelsena lite i förväg, för vi får nog diskutera det på ett styretmöte först. Men internt i presidiet och tror vi detta är den bästa kompromissen vi kan göra som möjliggör deltagande på lika principer.

#### Bakgrund
Zoom har konverterat feedback till reaktioner i nyaste versionen (tänk när man applåderade med en emoji på sin kamera). Detta innebär att rösterna bara ligger uppe i ett tiotal sekunder innan de försvinner, så det blir omöjligt att räkna dem (åtminstone vid bara ett tryck).