### PR TITLE
Felmeddelande vid utjustering

### DIFF
--- a/config/locales/views_controllers/vote_users.sv.yml
+++ b/config/locales/views_controllers/vote_users.sv.yml
@@ -32,4 +32,6 @@ sv:
       present: Injusterad
       short_error_not_present: Utjustering misslyckades
       short_error_present: Injustering misslyckades
+      all_not_present: Alla användare utjusterade
+      error_all_not_present: Misslyckades med att justera ut alla användare (finns det en aktiv dagordningspunkt?)
     votecode_error_short: Kunde inte nollställa


### PR DESCRIPTION
Slösade precis 10 minuter av mitt liv på att man inte kan justera ut någon om en dagordningspunkt inte är öppen **(Jättedumt)**. Ett felmeddelande saknas för detta om man försöker justera ut alla (det finns hjälptext om man justerar ut en enskild) så med lite hjälptext kanske man inte behöver bli så förvirrad framöver.