### PR TITLE
Create devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+	"name": "Sektionsmote",
+	"dockerComposeFile": "./docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/usr/src/app",
+	"forwardPorts": [3000],
+	"postStartCommand": "ruby ./bin/setup && bundle exec rails server -b 0.0.0.0"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,14 +6,15 @@ services:
       POSTGRES_USER: root
       RAILS_ENV: development
     volumes:
-      - ./.docker/volumes/database:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql/data
     
 
   app:
     build:
-      context: .
+      context: ..
       dockerfile: Dockerfile
-    command: sh -c "ruby ./bin/setup && bundle exec rails server -b 0.0.0.0"
+      target: development
+    command: sleep infinity
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: root
@@ -25,3 +26,5 @@ services:
     depends_on:
       - db
     
+volumes:
+  db-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_USER: root
       RAILS_ENV: development
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - ./.docker/volumes/database:/var/lib/postgresql/data
     
 
   app:
@@ -26,5 +26,4 @@ services:
     depends_on:
       - db
     
-volumes:
-  db-data:
+

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,9 @@
+.git/
+.circleci/
+.devcontainer/
+Dockerfile
+
+
 *.rbc
 *.sassc
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the ruby version specified in Gemfile.lock
-FROM ruby:2.7.2-alpine3.13
+FROM ruby:2.7.2-alpine3.13 AS development
 WORKDIR /usr/src/app
 
 # Required by bundler
@@ -15,6 +15,10 @@ RUN apk add nodejs
 # Uppdate bundler to the version specified in Gemfile.lock
 RUN gem install bundler:2.2.8
 
+FROM development AS production
+
+COPY . /usr/src/app/
+RUN bundle install
 
 EXPOSE 3000
-
+CMD ruby ./bin/setup && bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
List of changes

1. Use a named volume for postgres instead of bind mount (if you dont need to view/edit the data on the host computer, there is no reason not to use a normal volume)
2. Moved Dockerfile up one directory. This is so that the Dockerfile is allowed to copy all files when building the image, otherwise the context is too restrictive being inside the .devcontainer folder. (And also it looks nicer)
3. Added a .dockerignore file
4. Added multistage builds for development/production. As the default command in the development build exits automatically, we need to send `command: sleep infinity` in docker-compose.yml to prevent the container from exiting. `ruby ./bin/setup && bundle exec rails server -b 0.0.0.0` is run from devcontainer.json instead, since this way the output from this command will be visible when opening the devcontainer. If it is specified as `command` either in docker-compose.yml or Dockerfile (`CMD`), it will run very slowly in the background inside the devcontainer and it will not be obvious to the user what is happening since the command output is not visible anywhere